### PR TITLE
feat(qr-formatter): add QR content formatter service and interface

### DIFF
--- a/Lab 6/QrCodeGenerator/QrCodeGenerator/Services/QrContentFormatterService.cs
+++ b/Lab 6/QrCodeGenerator/QrCodeGenerator/Services/QrContentFormatterService.cs
@@ -1,0 +1,38 @@
+﻿using QrCodeGenerator.Models;
+using System.Text.RegularExpressions;
+
+namespace QrCodeGenerator.Services
+{
+    public interface IQrContentFormatterService
+    {
+        string Format(QrInputModel model);
+    }
+
+    public class QrContentFormatterService : IQrContentFormatterService
+    {
+        public string Format(QrInputModel model)
+        {
+            return model.QrType switch
+            {
+                "Email" when IsValidEmail(model.EmailTo) =>
+                    $"mailto:{model.EmailTo}?subject={Uri.EscapeDataString(model.Subject ?? "")}&body={Uri.EscapeDataString(model.Body ?? "")}",
+
+                "SMS" when IsValidPhone(model.PhoneNumber) =>
+                    $"SMSTO:{model.PhoneNumber}:{model.SmsMessage ?? ""}",
+
+                "WiFi" when !string.IsNullOrWhiteSpace(model.WifiSSID) =>
+                    $"WIFI:T:{(model.WifiEncryption ?? "WPA")};S:{model.WifiSSID};P:{model.WifiPassword ?? ""};;",
+
+                _ => model.Text ?? ""
+            };
+        }
+
+        private bool IsValidEmail(string? email) =>
+            !string.IsNullOrWhiteSpace(email) &&
+            Regex.IsMatch(email, @"^[^@\s]+@[^@\s]+\.[^@\s]+$");
+
+        private bool IsValidPhone(string? phone) =>
+            !string.IsNullOrWhiteSpace(phone) &&
+            Regex.IsMatch(phone, @"^\+?\d{10,}$");
+    }
+}


### PR DESCRIPTION
Added QrContentFormatterService to format QR content based on the selected QR code type.
Supported formats:
- Email – generates mailto: link with subject and body fields
- SMS – generates SMSTO: link with phone number and message
- WiFi – generates WIFI: config string including encryption type, SSID, and password
- Plain Text – falls back to raw text input

